### PR TITLE
[node][memory] Garbage collect cache sooner

### DIFF
--- a/browser-weakref.js
+++ b/browser-weakref.js
@@ -1,0 +1,3 @@
+module.exports = function(v) { return v; }
+module.exports.isDead = function() { return false; }
+module.exports.get = function(v) { return v; }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.6",
   "description": "Throttle depending on function arguments.",
   "main": "index.js",
+  "browser": {
+    "weak-napi": "./browser-weakref"
+  },
   "engines": {
     "node": "6.x.x"
   },
@@ -37,5 +40,8 @@
   "bugs": {
     "url": "https://github.com/ambassify/throttle/issues"
   },
-  "homepage": "https://github.com/ambassify/throttle#readme"
+  "homepage": "https://github.com/ambassify/throttle#readme",
+  "dependencies": {
+    "weak-napi": "^1.0.3"
+  }
 }


### PR DESCRIPTION
In nodejs we are able to garbage collect memory quicker if we don't
keep a reference to it from the cleanup timeout.

This is particularly important to services with short-lived throttled
functions such as our mail worker.

Since browsers don't support native modules and don't provide
[WeakRef](https://github.com/tc39/proposal-weakrefs) yet we keep the
old behaviour. It should also be less problematic there since throttled
functions are not being created in the same amounts.