### PR TITLE
[weakref] Add support for tc39 WeakRef

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-    build:
+    build-latest: &common-build
         docker:
             - image: node:latest
         steps:
@@ -15,3 +15,35 @@ jobs:
             - run: npm test
             - store_artifacts:
                 path: coverage
+
+    build-v8:
+        <<: *common-build
+        docker:
+            - image: node:8
+
+    build-v10:
+        <<: *common-build
+        docker:
+            - image: node:10
+
+    build-v12:
+        <<: *common-build
+        docker:
+            - image: node:12
+
+    build-v12-weakref:
+        <<: *common-build
+        environment:
+            HARMONY_OPTIONS: --harmony-weak-refs
+        docker:
+            - image: node:12
+
+workflows:
+    version: 2
+    build_and_test:
+        jobs:
+            - build-latest
+            - build-v8
+            - build-v10
+            - build-v12
+            - build-v12-weakref

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Throttle depending on function arguments.",
   "main": "index.js",
   "browser": {
-    "./weakref": "./weakref-browser"
+    "./weakref": "./weakref-generic"
   },
   "engines": {
     "node": "6.x.x"
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "npm -s run test:lint & npm -s run test:unit",
     "test:lint": "eslint index.js",
-    "test:unit": "nyc mocha",
+    "test:unit": "nyc mocha $HARMONY_OPTIONS",
     "release": "npm version patch && npm publish"
   },
   "keywords": [

--- a/test/weakref.js
+++ b/test/weakref.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+
+describe('weakref', () => {
+
+    let weak;
+
+    before(() => {
+        weak = require('../weakref');
+    });
+
+    it ('should have WeakRef when harmony flag is enabled', function() {
+        const { HARMONY_OPTIONS = '' } = process.env;
+
+        if (!/--harmony-weak-refs/.test(HARMONY_OPTIONS))
+            return this.skip();
+
+        assert.notEqual(typeof WeakRef, 'undefined');
+        assert.notEqual(weak.isUnsupported, true, 'reported unsupported');
+    });
+
+    it ('should create a weak ref', () => {
+        const a = { test: 'yes' };
+
+        const ref = weak(a);
+
+        assert(ref);
+
+        assert.strictEqual(weak.get(ref), a);
+    });
+
+    it ('should create a weak ref', () => {
+        const a = { test: 'yes' };
+
+        const ref = weak(a);
+
+        assert(ref);
+
+        assert.strictEqual(weak.get(ref), a);
+    });
+
+    it ('should detect refs that are not dead yet', () => {
+        const a = { test: 'yes' };
+        const ref = weak(a);
+
+        assert(!weak.isDead(ref), 'weakref is dead');
+    });
+
+    it ('should detect when refs become dead', function(done) {
+        if (weak.isUnsupported)
+            return this.skip();
+
+        this.timeout(15000);
+
+        const ref = (function() {
+            const a = { test: 'yes' };
+            return weak(a);
+        }());
+
+        function isDeadYet() {
+            if (weak.isDead(ref))
+                return done();
+
+            setTimeout(isDeadYet, 250);
+        }
+
+        isDeadYet();
+    });
+
+});

--- a/weakref-browser.js
+++ b/weakref-browser.js
@@ -1,3 +1,0 @@
-module.exports = function(v) { return v; }
-module.exports.isDead = function() { return false; }
-module.exports.get = function(v) { return v; }

--- a/weakref-generic.js
+++ b/weakref-generic.js
@@ -1,0 +1,18 @@
+/* globals WeakRef */
+
+// https://github.com/tc39/proposal-weakrefs
+// Can be enabled on node using --harmony-weak-refs flag
+const supportsWeakRef = (typeof WeakRef != 'undefined');
+
+if (supportsWeakRef) {
+    module.exports = function(v) { return new WeakRef(v); }
+    module.exports.get = function(v) { return v.deref(); }
+    module.exports.isDead = function(v) {
+        return (typeof v.deref() == 'undefined');
+    }
+} else {
+    module.exports = function(v) { return v; }
+    module.exports.get = function(v) { return v; }
+    module.exports.isDead = function() { return false; }
+    module.exports.isUnsupported = true;
+}

--- a/weakref.js
+++ b/weakref.js
@@ -1,5 +1,5 @@
 const nodeMajorVersion = parseInt(process.versions.node.replace(/\..*/, ''));
 
 module.exports = nodeMajorVersion >= 12 ?
-    require('./weakref-browser') : // https://github.com/node-ffi-napi/weak-napi/issues/16
+    require('./weakref-generic') : // https://github.com/node-ffi-napi/weak-napi/issues/16
     require('weak-napi');


### PR DESCRIPTION
This adds alternative `WeakRef` support for node version 12 using the currently `harmony` feature in node >= 12.

This requires the `--harmony-weak-refs` flag for nodejs.

https://tc39.es/proposal-weakrefs/